### PR TITLE
Adding https support to all emitters

### DIFF
--- a/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/emitters/AsyncBatchEmitter.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/emitters/AsyncBatchEmitter.scala
@@ -27,10 +27,11 @@ object AsyncBatchEmitter {
    * @param host collector host
    * @param port collector port
    * @param bufferSize quantity of events in batch request
+   * @param https should this use the https scheme
    * @return emitter
    */
-  def createAndStart(host: String, port: Int = 80, bufferSize: Int = 50): AsyncBatchEmitter = {
-    val emitter = new AsyncBatchEmitter(host, port, bufferSize)
+  def createAndStart(host: String, port: Int = 80, bufferSize: Int = 50, https: Boolean = false): AsyncBatchEmitter = {
+    val emitter = new AsyncBatchEmitter(host, port, bufferSize, https = https)
     emitter.startWorker()
     emitter
   }
@@ -43,8 +44,9 @@ object AsyncBatchEmitter {
  * @param host collector host
  * @param port collector port
  * @param bufferSize quantity of events in a batch request
+ * @param https should this use the https scheme
  */
-class AsyncBatchEmitter private(host: String, port: Int, bufferSize: Int) extends TEmitter {
+class AsyncBatchEmitter private(host: String, port: Int, bufferSize: Int, https: Boolean = false) extends TEmitter {
 
   val queue = new LinkedBlockingQueue[Seq[Map[String, String]]]()
 
@@ -58,7 +60,7 @@ class AsyncBatchEmitter private(host: String, port: Int, bufferSize: Int) extend
     override def run {
       while (true) {
         val batch = queue.take()
-        RequestUtils.retryPostUntilSuccessful(host, batch, port, initialBackoffPeriod)
+        RequestUtils.retryPostUntilSuccessful(host, batch, port, initialBackoffPeriod, https = https)
       }
     }
   }

--- a/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/emitters/AsyncEmitter.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/emitters/AsyncEmitter.scala
@@ -23,10 +23,11 @@ object AsyncEmitter {
    *
    * @param host collector host
    * @param port collector port
+   * @param https should this use the https scheme
    * @return emitter
    */
-  def createAndStart(host: String, port: Int = 80): AsyncEmitter = {
-    val emitter = new AsyncEmitter(host, port)
+  def createAndStart(host: String, port: Int = 80, https: Boolean = false): AsyncEmitter = {
+    val emitter = new AsyncEmitter(host, port, https)
     emitter.startWorker()
     emitter
   }
@@ -37,8 +38,9 @@ object AsyncEmitter {
  *
  * @param host collector host
  * @param port collector port
+ * @param https should this use the https scheme
  */
-class AsyncEmitter private(host: String, port: Int) extends TEmitter {
+class AsyncEmitter private(host: String, port: Int, https: Boolean = false) extends TEmitter {
 
   val queue = new LinkedBlockingQueue[Map[String, String]]()
 
@@ -50,7 +52,7 @@ class AsyncEmitter private(host: String, port: Int) extends TEmitter {
     override def run {
       while (true) {
         val event = queue.take()
-        RequestUtils.retryGetUntilSuccessful(host, event, port, initialBackoffPeriod)
+        RequestUtils.retryGetUntilSuccessful(host, event, port, initialBackoffPeriod, https = https)
       }
     }
   }

--- a/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/emitters/RequestUtils.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/emitters/RequestUtils.scala
@@ -87,11 +87,12 @@ object RequestUtils {
    * @param host URL host (not header)
    * @param payload map of event keys
    * @param port URL port (not header)
+   * @param https should this request use the https scheme
    * @return HTTP request with event
    */
-  private[emitters] def constructGetRequest(host: String, payload: Map[String, String], port: Int): HttpRequest = {
+  private[emitters] def constructGetRequest(host: String, payload: Map[String, String], port: Int, https: Boolean = false): HttpRequest = {
     val uri = Uri()
-      .withScheme("http")
+      .withScheme(Uri.httpScheme(https))
       .withPath(Uri.Path("/i"))
       .withAuthority(Uri.Authority(Uri.Host(host), port))
       .withQuery(payload)
@@ -104,11 +105,12 @@ object RequestUtils {
    * @param host URL host (not header)
    * @param payload list of events
    * @param port URL port (not header)
+   * @param https should this request use the https scheme
    * @return HTTP request with event
    */
-  private[emitters] def constructPostRequest(host: String, payload: Seq[Map[String, String]], port: Int): HttpRequest = {
+  private[emitters] def constructPostRequest(host: String, payload: Seq[Map[String, String]], port: Int, https: Boolean = false): HttpRequest = {
     val uri = Uri()
-      .withScheme("http")
+      .withScheme(Uri.httpScheme(https))
       .withPath(Uri.Path("/com.snowplowanalytics.snowplow/tp2"))
       .withAuthority(Uri.Authority(Uri.Host(host), port))
     Post(uri, payload)
@@ -120,11 +122,12 @@ object RequestUtils {
    * @param host collector host
    * @param payload event map
    * @param port collector port
+   * @param https should this request use the https scheme
    * @return Whether the request succeeded
    */
-  def attemptGet(host: String, payload: Map[String, String], port: Int = 80): Boolean = {
+  def attemptGet(host: String, payload: Map[String, String], port: Int = 80, https: Boolean = false): Boolean = {
     val payloadWithStm = payload ++ Map("stm" -> System.currentTimeMillis().toString)
-    val req = constructGetRequest(host, payloadWithStm, port)
+    val req = constructGetRequest(host, payloadWithStm, port, https)
     val future = pipeline(req)
     val result = Await.ready(future, longTimeout).value.get
     result match {
@@ -142,17 +145,25 @@ object RequestUtils {
    * @param port collector port
    * @param backoffPeriod How long to wait after first failed request
    * @param attempt accumulated value of tries
+   * @param https should this request use the https scheme
    */
-  def retryGetUntilSuccessful(host: String, payload: Map[String, String], port: Int = 80, backoffPeriod: Long, attempt: Int = 1) {
+  def retryGetUntilSuccessful(
+       host: String,
+       payload: Map[String, String],
+       port: Int = 80,
+       backoffPeriod: Long,
+       attempt: Int = 1,
+       https: Boolean = false) {
+
     val getSuccessful = try {
-      attemptGet(host, payload, port)
+      attemptGet(host, payload, port, https)
     } catch {
       case NonFatal(f) => false
     }
 
     if (!getSuccessful && attempt < 10) {
       Thread.sleep(backoffPeriod)
-      retryGetUntilSuccessful(host, payload, port, backoffPeriod * 2, attempt + 1)
+      retryGetUntilSuccessful(host, payload, port, backoffPeriod * 2, attempt + 1, https)
     }
   }
 
@@ -162,12 +173,13 @@ object RequestUtils {
    * @param host collector host
    * @param payload event map
    * @param port collector port
+   * @param https should this request use the https scheme
    * @return Whether the request succeeded
    */
-  def attemptPost(host: String, payload: Seq[Map[String, String]], port: Int = 80): Boolean = {
+  def attemptPost(host: String, payload: Seq[Map[String, String]], port: Int = 80, https: Boolean = false): Boolean = {
     val stm = System.currentTimeMillis().toString
     val payloadWithStm = payload.map(_ ++ Map("stm" -> stm))
-    val req = constructPostRequest(host, payloadWithStm, port)
+    val req = constructPostRequest(host, payloadWithStm, port, https)
     val future = pipeline(req)
     val result = Await.ready(future, longTimeout).value.get
     result match {
@@ -185,17 +197,25 @@ object RequestUtils {
    * @param port collector port
    * @param backoffPeriod How long to wait after first failed request
    * @param attempt accumulated value of tries
+   * @param https should this request use the https scheme
    */
-  def retryPostUntilSuccessful(host: String, payload: Seq[Map[String, String]], port: Int = 80, backoffPeriod: Long, attempt: Int = 1) {
+  def retryPostUntilSuccessful(
+      host: String,
+      payload: Seq[Map[String, String]],
+      port: Int = 80,
+      backoffPeriod: Long,
+      attempt: Int = 1,
+      https: Boolean = false) {
+
     val getSuccessful = try {
-      attemptPost(host, payload, port)
+      attemptPost(host, payload, port, https)
     } catch {
       case NonFatal(f) => false
     }
 
     if (!getSuccessful && attempt < 10) {
       Thread.sleep(backoffPeriod)
-      retryPostUntilSuccessful(host, payload, port, backoffPeriod * 2, attempt + 1)
+      retryPostUntilSuccessful(host, payload, port, backoffPeriod * 2, attempt + 1, https)
     }
   }
 

--- a/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/emitters/SyncEmitter.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/emitters/SyncEmitter.scala
@@ -17,10 +17,11 @@ package com.snowplowanalytics.snowplow.scalatracker.emitters
  *
  * @param host
  * @param port
+ * @param https
  */
-class SyncEmitter(host: String, port: Int = 80) extends TEmitter {
+class SyncEmitter(host: String, port: Int = 80, https: Boolean = false) extends TEmitter {
 
   def input(event: Map[String, String]): Unit = {
-    RequestUtils.attemptGet(host, event, port)
+    RequestUtils.attemptGet(host, event, port, https)
   }
 }


### PR DESCRIPTION
This PR is adding https as a scheme for the collector url, so that you can push tracking events from your application to the collector over https. 
This allows you to do load balancer https termination for your collector, and keep your events data secured in transit.
This is a slightly verbose implementation, but it was the least intrusive way of adding the change and providing backwards compatibility with the current version.
