### PR TITLE
Migrate from json4s to circe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,11 +32,12 @@ lazy val root = project
   .settings(
     libraryDependencies ++= Seq(
       Dependencies.Libraries.scalajHttp,
-      Dependencies.Libraries.json4sJackson,
       Dependencies.Libraries.igluCore,
-      Dependencies.Libraries.igluCoreJson4s,
+      Dependencies.Libraries.circe,
+      Dependencies.Libraries.igluCoreCirce,
       Dependencies.Libraries.mockito,
       Dependencies.Libraries.specs2,
-      Dependencies.Libraries.scalaCheck
+      Dependencies.Libraries.scalaCheck,
+      Dependencies.Libraries.circeOptics
     )
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,8 +17,8 @@ object Dependencies {
   object V {
     // Scala
     val scalajHttp = "2.3.0"
-    val json4s     = "3.2.11"
     val igluCore   = "0.2.0"
+    val circe      = "0.9.3"
 
     // Java (test only)
     val mockito    = "1.9.5"
@@ -31,15 +31,16 @@ object Dependencies {
   object Libraries {
     // Scala
     val scalajHttp     = "org.scalaj"            %% "scalaj-http"      % V.scalajHttp
-    val json4sJackson  = "org.json4s"            %% "json4s-jackson"   % V.json4s
     val igluCore       = "com.snowplowanalytics" %% "iglu-core"        % V.igluCore
-    val igluCoreJson4s = "com.snowplowanalytics" %% "iglu-core-json4s" % V.igluCore
+    val igluCoreCirce  = "com.snowplowanalytics" %% "iglu-core-circe"  % V.igluCore
+    val circe          = "io.circe"              %% "circe-parser"     % V.circe
 
     // Java (test only)
-    val mockito       = "org.mockito"       %  "mockito-all"    % V.mockito       % "test"
+    val mockito       = "org.mockito"             % "mockito-all"    % V.mockito       % "test"
 
     // Scala (test only)
-    val specs2        = "org.specs2"         %% "specs2-core"    % V.specs2        % "test"
-    val scalaCheck    = "org.scalacheck"     %% "scalacheck"     % V.scalaCheck    % "test"
+    val specs2        = "org.specs2"             %% "specs2-core"    % V.specs2        % "test"
+    val scalaCheck    = "org.scalacheck"         %% "scalacheck"     % V.scalaCheck    % "test"
+    val circeOptics   = "io.circe"               %% "circe-optics"   % V.circe         % "test"
   }
 }

--- a/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/Payload.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/Payload.scala
@@ -14,10 +14,9 @@ package com.snowplowanalytics.snowplow.scalatracker
 
 import java.util.Base64
 
-import org.json4s._
-import org.json4s.jackson.JsonMethods._
-
 import scala.collection.mutable.{Map => MMap}
+
+import io.circe.Json
 
 import emitters.TEmitter.EmitterPayload
 
@@ -68,9 +67,9 @@ private[scalatracker] class Payload {
    * @param typeWhenEncoded Key to use if encodeBase64 is true
    * @param typeWhenNotEncoded Key to use if encodeBase64 is false
    */
-  def addJson(json: JValue, encodeBase64: Boolean, typeWhenEncoded: String, typeWhenNotEncoded: String): Unit = {
+  def addJson(json: Json, encodeBase64: Boolean, typeWhenEncoded: String, typeWhenNotEncoded: String): Unit = {
 
-    val jsonString = compact(render(json))
+    val jsonString = json.noSpaces
 
     if (encodeBase64) {
       add(typeWhenEncoded, new String(Base64.getEncoder.encode(jsonString.getBytes(Encoding)), Encoding))

--- a/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/Tracker.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/Tracker.scala
@@ -19,14 +19,14 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
-import org.json4s._
-import org.json4s.JsonDSL._
+import io.circe.Json
+import io.circe.syntax._
 
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
-import com.snowplowanalytics.iglu.core.json4s.implicits._
+import com.snowplowanalytics.iglu.core.circe.implicits._
 
+import utils.{ErrorTracking, JsonUtils}
 import emitters.TEmitter
-import utils.ErrorTracking
 
 /**
  * Tracker class
@@ -112,7 +112,7 @@ class Tracker(emitters: Seq[TEmitter], namespace: String, appId: String, encodeB
   private def addContexts(payload: Payload, contexts: Seq[SelfDescribingJson]): Payload =
     if (contexts.nonEmpty) {
       val contextsEnvelope: SelfDescribingJson =
-        SelfDescribingData(ContextsSchemaKey, JArray(contexts.toList.map(_.normalize)))
+        SelfDescribingData(ContextsSchemaKey, Json.fromValues(contexts.toIterable.map(_.normalize)))
 
       payload.addJson(contextsEnvelope.normalize, encodeBase64, "cx", "co")
       payload
@@ -309,13 +309,14 @@ class Tracker(emitters: Seq[TEmitter], namespace: String, appId: String, encodeB
                      contexts: List[SelfDescribingJson] = Nil,
                      timestamp: Option[Timestamp]       = None): Tracker = {
 
-    val eventJson =
-      ("sku"         -> sku) ~
-        ("name"      -> name) ~
-        ("category"  -> category) ~
-        ("unitPrice" -> unitPrice) ~
-        ("quantity"  -> quantity) ~
-        ("currency"  -> currency)
+    val eventJson = JsonUtils.jsonObjectWithoutNulls(
+      "sku" := sku,
+      "name" := name,
+      "category" := category,
+      "unitPrice" := unitPrice,
+      "quantity" := quantity,
+      "currency" := currency
+    )
 
     trackSelfDescribingEvent(
       SelfDescribingData(
@@ -347,13 +348,14 @@ class Tracker(emitters: Seq[TEmitter], namespace: String, appId: String, encodeB
                           contexts: List[SelfDescribingJson] = Nil,
                           timestamp: Option[Timestamp]       = None): Tracker = {
 
-    val eventJson =
-      ("sku"         -> sku) ~
-        ("name"      -> name) ~
-        ("category"  -> category) ~
-        ("unitPrice" -> unitPrice) ~
-        ("quantity"  -> quantity) ~
-        ("currency"  -> currency)
+    val eventJson = JsonUtils.jsonObjectWithoutNulls(
+      "sku" := sku,
+      "name" := name,
+      "category" := category,
+      "unitPrice" := unitPrice,
+      "quantity" := quantity,
+      "currency" := currency
+    )
 
     trackSelfDescribingEvent(
       SelfDescribingData(

--- a/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/Tracker.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/Tracker.scala
@@ -121,21 +121,6 @@ class Tracker(emitters: Seq[TEmitter], namespace: String, appId: String, encodeB
     }
 
   /**
-   * Track a Snowplow unstructured event
-   * Alias for `trackSelfDescribingEvent`
-   *
-   * @param unstructEvent self-describing JSON for the event
-   * @param contexts list of additional contexts
-   * @param timestamp optional user-provided timestamp (ms) for the event
-   * @return The tracker instance
-   */
-  @deprecated("Use Tracker#trackSelfDescribingEvent instead", "0.4.0")
-  def trackUnstructEvent(unstructEvent: SelfDescribingJson,
-                         contexts: Seq[SelfDescribingJson] = Nil,
-                         timestamp: Option[Timestamp]      = None): Tracker =
-    trackSelfDescribingEvent(unstructEvent, contexts, timestamp)
-
-  /**
    * Track a Snowplow self-describing event
    *
    * @param unstructEvent self-describing JSON for the event

--- a/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/emitters/AsyncBatchEmitter.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/emitters/AsyncBatchEmitter.scala
@@ -68,12 +68,11 @@ class AsyncBatchEmitter private (ec: ExecutionContext,
 
   // Start consumer thread synchronously trying to send events to collector
   val worker = new Thread {
-    override def run() {
+    override def run(): Unit =
       while (true) {
         val batch = queue.take()
         submit(queue, ec, callback, collector, batch)
       }
-    }
   }
 
   worker.setDaemon(true)

--- a/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/emitters/AsyncEmitter.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/emitters/AsyncEmitter.scala
@@ -54,12 +54,11 @@ class AsyncEmitter private (ec: ExecutionContext, collector: CollectorParams, ca
   val queue = new LinkedBlockingQueue[CollectorRequest]()
 
   val worker = new Thread {
-    override def run() {
+    override def run(): Unit =
       while (true) {
         val event = queue.take()
         submit(queue, ec, callback, collector, event)
       }
-    }
   }
 
   worker.setDaemon(true)

--- a/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/utils/JsonUtils.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow/scalatracker/utils/JsonUtils.scala
@@ -10,25 +10,13 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow
+package com.snowplowanalytics.snowplow.scalatracker.utils
 
-import com.snowplowanalytics.iglu.core.{SchemaKey, SelfDescribingData}
 import io.circe.Json
 
-package object scalatracker {
+object JsonUtils {
 
-  /** Tracker-specific self-describing JSON */
-  type SelfDescribingJson = SelfDescribingData[Json]
+  def jsonObjectWithoutNulls(fields: (String, Json)*): Json =
+    Json.fromFields(fields.filter { case (_, json) => !json.isNull })
 
-  /** Backward-compatibility */
-  object SelfDescribingJson {
-    @deprecated("Use com.snowplowanalytics.iglu.core.SchemaKey instead", "0.5.0")
-    def apply(key: String, data: Json): SelfDescribingJson =
-      SelfDescribingData[Json](
-        SchemaKey
-          .fromUri(key)
-          .getOrElse(
-            throw new RuntimeException(s"Invalid SchemaKey $key. Use com.snowplowanalytics.iglu.core.SchemaKey")),
-        data)
-  }
 }

--- a/src/test/scala/com.snowplowanalytics.snowplow.scalatracker/PayloadSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.scalatracker/PayloadSpec.scala
@@ -12,10 +12,9 @@
  */
 package com.snowplowanalytics.snowplow.scalatracker
 
-// json4s
-import org.json4s._
-import org.json4s.JsonDSL._
-import org.json4s.jackson.JsonMethods._
+// circe
+import io.circe.Json
+import io.circe.syntax._
 
 // Specs2
 import org.specs2.mutable.Specification
@@ -53,7 +52,7 @@ class PayloadSpec extends Specification {
 
       val payload = new Payload()
 
-      payload.addJson(("k" -> "v"), false, "enc", "plain")
+      payload.addJson(Json.obj("k" := "v"), false, "enc", "plain")
 
       payload.get must_== Map("plain" -> """{"k":"v"}""")
     }
@@ -62,7 +61,7 @@ class PayloadSpec extends Specification {
 
       val payload = new Payload()
 
-      payload.addJson(("k" -> "v"), true, "enc", "plain")
+      payload.addJson(Json.obj("k" := "v"), true, "enc", "plain")
 
       payload.get must_== Map("enc" -> "eyJrIjoidiJ9")
     }

--- a/src/test/scala/com.snowplowanalytics.snowplow.scalatracker/TrackerSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.scalatracker/TrackerSpec.scala
@@ -52,7 +52,7 @@ class TrackerSpec extends Specification {
   "trackUnstructEvent" should {
 
     "send an unstructured event to the emitter" in new DummyTracker {
-      tracker.trackUnstructEvent(unstructEventJson)
+      tracker.trackSelfDescribingEvent(unstructEventJson)
 
       val event = emitter.lastInput
 


### PR DESCRIPTION
This is a followup to #91 and depends on it. This PR purposefully focuses only on migrating to circe -  minimizing changes to the API, keeping all the exceptions, unsafe code etc. (I'll focus on these with #74 and #46).