### PR TITLE
Drop 2.11 support, add 2.13 support, update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
-- 2.11.12
-- 2.12.6
+- 2.12.12
+- 2.13.3
 jdk:
 - openjdk8
 script:

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ limitations under the License.
 [license-image]: https://img.shields.io/badge/license-Apache--2-blue.svg?style=flat
 [license]: https://www.apache.org/licenses/LICENSE-2.0
 
-[maven-badge]: https://maven-badges.herokuapp.com/maven-central/com.snowplowanalytics/snowplow-scala-tracker_2.12/badge.svg
-[maven]: https://maven-badges.herokuapp.com/maven-central/com.snowplowanalytics/snowplow-scala-tracker_2.12
+[maven-badge]: https://maven-badges.herokuapp.com/maven-central/com.snowplowanalytics/snowplow-scala-tracker-core_2.12/badge.svg
+[maven]: https://maven-badges.herokuapp.com/maven-central/com.snowplowanalytics/snowplow-scala-tracker-core_2.12
 
 [codecov-badge]: https://codecov.io/gh/snowplow/snowplow-scala-tracker/branch/master/graph/badge.svg
 [codecov]: https://codecov.io/gh/snowplow/snowplow-scala-tracker

--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,9 @@
 lazy val commonSettings = Seq(
   organization := "com.snowplowanalytics",
   version := "0.6.1",
-  scalaVersion := "2.12.6",
-  crossScalaVersions := Seq("2.11.12", "2.12.6"),
-  scalacOptions := BuildSettings.compilerOptions,
+  scalaVersion := "2.13.3",
+  crossScalaVersions := Seq("2.12.12", "2.13.3"),
+  scalacOptions := BuildSettings.compilerOptions(scalaVersion.value),
   javacOptions ++= BuildSettings.javaCompilerOptions,
   libraryDependencies ++= Seq(
     Dependencies.Libraries.specs2,

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.scalatracker/TrackerSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.scalatracker/TrackerSpec.scala
@@ -221,7 +221,7 @@ class TrackerSpec extends Specification {
 
       val event = lastInput
 
-      val json = parse(event("ue_pr")).right.get
+      val json = parse(event("ue_pr")).getOrElse(Json.Null)
 
       val data = root.data.data
 
@@ -240,7 +240,6 @@ class TrackerSpec extends Specification {
     }
 
     "uses default message" >> {
-      import cats.implicits._
 
       "when there is no error message" in new DummyTracker {
         val error = new RuntimeException()

--- a/modules/id-emitter/src/test/scala/com/snowplowanalytics/snowplow/scalatracker/emitters/id/StressTest.scala
+++ b/modules/id-emitter/src/test/scala/com/snowplowanalytics/snowplow/scalatracker/emitters/id/StressTest.scala
@@ -22,7 +22,7 @@ import io.circe.syntax._
 import io.circe.parser.parse
 
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
-import com.snowplowanalytics.iglu.core.circe.instances._
+import com.snowplowanalytics.iglu.core.circe.implicits._
 import com.snowplowanalytics.snowplow.scalatracker.Tracker.{DeviceCreatedTimestamp, Timestamp, TrueTimestamp}
 import com.snowplowanalytics.snowplow.scalatracker.{SelfDescribingJson, Tracker}
 

--- a/modules/metadata/src/test/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/MetadataSpec.scala
+++ b/modules/metadata/src/test/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/MetadataSpec.scala
@@ -28,7 +28,8 @@ class MetadataSpec extends Specification with Mockito {
 
   import com.snowplowanalytics.snowplow.scalatracker.syntax.id._
 
-  implicit val timer = IO.timer(global)
+  implicit val timer                          = IO.timer(global)
+  implicit val contextShift: ContextShift[IO] = IO.contextShift(global)
 
   val ec2Response = IO.pure("""
       |{
@@ -71,8 +72,6 @@ class MetadataSpec extends Specification with Mockito {
     override def send(event: EmitterPayload): Id[Unit] = ()
   }
 
-  implicit val contextShift: ContextShift[IO] = IO.contextShift(global)
-
   def e1 =
     Tracker(NonEmptyList.of(emitter), "foo", "foo")
       .enableEc2Context[IO]
@@ -92,7 +91,7 @@ class MetadataSpec extends Specification with Mockito {
       .returns(IO.sleep(5.seconds).map(_ => "foo"))
       .getMock[Ec2Metadata[IO]]
 
-    blockingInstance.getInstanceContextBlocking.unsafeRunSync must beNone
+    blockingInstance.getInstanceContextBlocking.unsafeRunSync() must beNone
   }
 
   def e4 = {
@@ -103,6 +102,6 @@ class MetadataSpec extends Specification with Mockito {
       .returns(IO.sleep(5.seconds).map(_ => "foo"))
       .getMock[GceMetadata[IO]]
 
-    blockingInstance.getInstanceContextBlocking.unsafeRunSync must beNone
+    blockingInstance.getInstanceContextBlocking.unsafeRunSync() must beNone
   }
 }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -12,9 +12,10 @@
  */
 import bintray.BintrayPlugin._
 import bintray.BintrayKeys._
-
 import sbt._
 import Keys._
+
+import scala.Seq
 
 // Scalafmt plugin
 import com.lucidchart.sbt.scalafmt.ScalafmtCorePlugin.autoImport._
@@ -37,7 +38,7 @@ object BuildSettings {
     }.taskValue
   )
 
-  lazy val compilerOptions = Seq(
+  def compilerOptions(scalaVersion: String) = Seq(
     "-deprecation",
     "-encoding", "UTF-8",
     "-feature",
@@ -45,17 +46,21 @@ object BuildSettings {
     "-language:higherKinds",
     "-language:implicitConversions",
     "-unchecked",
-    "-Ypartial-unification",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
-    "-Xfuture",
     "-Xlint"
-  )
+  ) ++ (if (priorTo2_13(scalaVersion)) Seq("-Ypartial-unification", "-Xfuture") else Nil )
 
   lazy val javaCompilerOptions = Seq(
     "-source", "1.8",
     "-target", "1.8"
   )
+
+  def priorTo2_13(scalaVersion: String): Boolean =
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, minor)) if minor < 13 => true
+      case _                              => false
+    }
 
   // Bintray publishing settings
   lazy val publishSettings = bintraySettings ++ Seq[Setting[_]](

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,15 +16,15 @@ object Dependencies {
 
   object V {
     // Scala
-    val scalajHttp  = "2.3.0"
-    val igluCore    = "0.5.1"
-    val circe       = "0.11.1"
-    val circeOptics = "0.11.0"
-    val catsEffect  = "1.3.1"
+    val scalajHttp  = "2.4.2"
+    val igluCore    = "1.0.0"
+    val circe       = "0.13.0"
+    val circeOptics = "0.13.0"
+    val catsEffect  = "2.2.0"
 
     // Scala (test only)
-    val specs2      = "4.3.2"
-    val scalaCheck  = "1.13.4"
+    val specs2      = "4.10.5"
+    val scalaCheck  = "1.14.3"
   }
 
   object Libraries {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.0
+sbt.version=1.4.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
 
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt-coursier" % "1.15")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt-coursier" % "1.16")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")


### PR DESCRIPTION
This PR bumps basically all dependencies, adds Scala 2.13 support and drops Scala 2.11 support (necessary to be able to bump cats-effect past 2.0.0 and circe to 0.13.0).

Resolves #126, #127, #128.
#106 and #130 may also be closed.