### PR TITLE
CE3 + http4s 0.23.x upgrade

### DIFF
--- a/modules/http4s-emitter/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/emitters/http4s/Http4sEmitter.scala
+++ b/modules/http4s-emitter/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/emitters/http4s/Http4sEmitter.scala
@@ -13,20 +13,19 @@
 package com.snowplowanalytics.snowplow.scalatracker.emitters.http4s
 
 import cats.{Monad, MonadThrow}
-import cats.effect.{Concurrent, Fiber, Resource, Sync, Timer}
+import cats.effect.{Async, Concurrent, Fiber, Resource, Sync, Temporal}
+import cats.effect.std.{Queue, Random}
 import cats.implicits._
 import com.snowplowanalytics.snowplow.scalatracker.{Buffer, Emitter, Payload}
 import com.snowplowanalytics.snowplow.scalatracker.Buffer.Action
 import com.snowplowanalytics.snowplow.scalatracker.Emitter._
 import fs2.{Pipe, Stream}
-import fs2.concurrent.{Dequeue, Enqueue, Queue}
 import org.http4s.{MediaType, Method, Uri, Request => HttpRequest}
 import org.http4s.client.Client
 import org.http4s.headers.`Content-Type`
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.duration._
-import scala.util.Random
 
 object Http4sEmitter {
 
@@ -42,7 +41,7 @@ object Http4sEmitter {
     * Pending events not sent within this timeout will be dropped. `None` means to wait indefinitely for sending
     * pending events when shutting down.
     */
-  def build[F[_]: Concurrent: Timer](
+  def build[F[_]: Async: Random](
     collector: EndpointParams,
     client: Client[F],
     bufferConfig: BufferConfig              = BufferConfig.Default,
@@ -58,25 +57,23 @@ object Http4sEmitter {
       } yield instance(queue, queuePolicy) -> shutdown(fiber, queue, shutdownTimeout)
     }
 
-  private def instance[F[_]](queue: Enqueue[F, Action], queuePolicy: EventQueuePolicy)(
-    implicit F: MonadThrow[F]
-  ): Emitter[F] =
+  private def instance[F[_]: MonadThrow](queue: Queue[F, Action], queuePolicy: EventQueuePolicy): Emitter[F] =
     new Emitter[F] {
       override def send(event: Payload): F[Unit] =
         queuePolicy match {
           case EventQueuePolicy.UnboundedQueue | EventQueuePolicy.BlockWhenFull(_) =>
-            queue.enqueue1(Action.Enqueue(event))
+            queue.offer(Action.Enqueue(event))
           case EventQueuePolicy.IgnoreWhenFull(_) =>
-            queue.offer1(Action.Enqueue(event)).void
+            queue.tryOffer(Action.Enqueue(event)).void
           case EventQueuePolicy.ErrorWhenFull(limit) =>
-            queue.offer1(Action.Enqueue(event)).flatMap {
-              case true  => F.unit
-              case false => F.raiseError(new EventQueuePolicy.EventQueueException(limit))
+            queue.tryOffer(Action.Enqueue(event)).flatMap {
+              case true  => MonadThrow[F].unit
+              case false => MonadThrow[F].raiseError(new EventQueuePolicy.EventQueueException(limit))
             }
         }
 
       override def flushBuffer(): F[Unit] =
-        queue.enqueue1(Action.Flush)
+        queue.offer(Action.Flush)
     }
 
   private def queueForPolicy[F[_]: Concurrent](policy: EventQueuePolicy): F[Queue[F, Action]] =
@@ -85,23 +82,23 @@ object Http4sEmitter {
       case None      => Queue.unbounded
     }
 
-  private def shutdown[F[_]: Concurrent: Timer](
-    fiber: Fiber[F, Unit],
-    queue: Enqueue[F, Action],
+  private def shutdown[F[_]: Concurrent: Temporal](
+    fiber: Fiber[F, Throwable, Unit],
+    queue: Queue[F, Action],
     timeout: Option[FiniteDuration]
   ): F[Unit] =
     timeout match {
       case Some(t) => shutdownWithTimeout(fiber, queue, t)
-      case None    => queue.enqueue1(Action.Terminate) *> fiber.join
+      case None    => queue.offer(Action.Terminate) *> fiber.join.void
     }
 
-  private def shutdownWithTimeout[F[_]: Concurrent: Timer](
-    fiber: Fiber[F, Unit],
-    queue: Enqueue[F, Action],
+  private def shutdownWithTimeout[F[_]: Concurrent: Temporal](
+    fiber: Fiber[F, Throwable, Unit],
+    queue: Queue[F, Action],
     timeout: FiniteDuration
   ): F[Unit] =
     // First try to enqueue the terminate event. This will block if the queue is full.
-    Concurrent[F].racePair(queue.enqueue1(Action.Terminate), Timer[F].sleep(timeout)).flatMap {
+    Concurrent[F].racePair(queue.offer(Action.Terminate), Temporal[F].sleep(timeout)).flatMap {
       case Left((_, timerFiber)) =>
         // We successfully enqueued the terminate event.
         // Next, wait for pending events to be sent to the collector.
@@ -120,23 +117,21 @@ object Http4sEmitter {
         fiber.cancel
     }
 
-  private def drainQueue[F[_]: Sync: Timer](
-    queue: Dequeue[F, Action],
+  private def drainQueue[F[_]: Async: Random](
+    queue: Queue[F, Action],
     client: Client[F],
     collector: EndpointParams,
     bufferConfig: BufferConfig,
     retryPolicy: RetryPolicy,
     callback: Option[Callback[F]]
   ): F[Unit] =
-    Sync[F].delay(new Random()).flatMap { rng =>
-      queue
-        .dequeue
-        .takeThrough(_ != Action.Terminate)
-        .through(bufferEvents(bufferConfig))
-        .evalMap(sendRequest(client, collector, retryPolicy, rng, callback))
-        .compile
-        .drain
-    }
+    Stream
+      .fromQueueUnterminated(queue)
+      .takeThrough(_ != Action.Terminate)
+      .through(bufferEvents(bufferConfig))
+      .evalMap(sendRequest(client, collector, retryPolicy, callback))
+      .compile
+      .drain
 
   private def bufferEvents[F[_]](bufferConfig: BufferConfig): Pipe[F, Action, Request] =
     _.mapAccumulate(Buffer(bufferConfig)) {
@@ -145,33 +140,32 @@ object Http4sEmitter {
       case (_, Some(flushed)) => flushed
     }
 
-  private def sendRequest[F[_]: Sync: Timer](
+  private def sendRequest[F[_]: Async: Random](
     client: Client[F],
     collector: EndpointParams,
     retryPolicy: RetryPolicy,
-    rng: Random,
     callback: Option[Callback[F]]
   ): Request => F[Unit] =
-    Sync[F].tailRecM(_) { request =>
+    Monad[F].tailRecM(_) { request =>
       attemptSend(client, collector, request).flatTap(invokeCallback(callback, collector, request, _)).flatMap {
         result =>
           if (result.isSuccess || request.isFailed(retryPolicy)) {
-            Sync[F].pure(Right(()))
+            Monad[F].pure(Right(()))
           } else {
             for {
-              seed <- Sync[F].delay(rng.nextDouble())
-              _    <- Timer[F].sleep(RetryPolicy.getDelay(request.attempt, seed).millis)
+              seed <- Random[F].nextDouble
+              _    <- Temporal[F].sleep(RetryPolicy.getDelay(request.attempt, seed).millis)
             } yield request.updateAttempt.asLeft
           }
       }
     }
 
-  private def attemptSend[F[_]: MonadThrow: Timer](
+  private def attemptSend[F[_]: Temporal](
     client: Client[F],
     collector: EndpointParams,
     request: Request
   ): F[Result] =
-    Timer[F].clock.realTime(MILLISECONDS).flatMap { dtm =>
+    Temporal[F].realTime.map(_.toMillis).flatMap { dtm =>
       val httpRequest = request.updateStm(dtm) match {
         case Request.Buffered(_, payload) =>
           val body = Stream.emits(Payload.postPayload(payload).getBytes).covary[F]
@@ -192,10 +186,10 @@ object Http4sEmitter {
           if (status.isSuccess) Result.Success(status.code)
           else Result.Failure(status.code)
         }
-        .handleError(Result.TrackerFailure(_))
+        .handleError(Result.TrackerFailure)
     }
 
-  lazy val logger = LoggerFactory.getLogger(getClass.getName)
+  lazy val logger: Logger = LoggerFactory.getLogger(getClass.getName)
 
   private def invokeCallback[F[_]: Sync](
     callback: Option[Callback[F]],

--- a/modules/http4s-emitter/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/emitters/http4s/package.scala
+++ b/modules/http4s-emitter/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/emitters/http4s/package.scala
@@ -12,19 +12,21 @@
  */
 package com.snowplowanalytics.snowplow.scalatracker.emitters
 
-import cats.effect.{Clock, Sync}
+import cats.implicits._
+import cats.effect.Clock
+import cats.effect.std.UUIDGen
+import cats.Functor
 import com.snowplowanalytics.snowplow.scalatracker.Tracking
 
 import java.util.UUID
 
 package object http4s {
 
-  implicit def ceTracking[F[_]: Clock: Sync]: Tracking[F] = new Tracking[F] {
-    import scala.concurrent.duration.MILLISECONDS
+  implicit def ceTracking[F[_]: Functor: Clock: UUIDGen]: Tracking[F] = new Tracking[F] {
 
-    override def getCurrentTimeMillis: F[Long] = Clock[F].realTime(MILLISECONDS)
+    override def getCurrentTimeMillis: F[Long] = Clock[F].realTime.map(_.toMillis)
 
-    override def generateUUID: F[UUID] = Sync[F].delay(UUID.randomUUID)
+    override def generateUUID: F[UUID] = UUIDGen.randomUUID
 
   }
 

--- a/modules/http4s-emitter/src/test/scala/com/snowplowanalytics/snowplow/scalatracker/emitters/http4s/Http4sEmitterSpec.scala
+++ b/modules/http4s-emitter/src/test/scala/com/snowplowanalytics/snowplow/scalatracker/emitters/http4s/Http4sEmitterSpec.scala
@@ -58,7 +58,7 @@ class Http4sEmitterSpec extends Specification {
       collector = Emitter.EndpointParams("example.com")
       client = Client[IO] { _ => Resource.eval(ref.update(_ + 1)).as(Response[IO]()) }
       emitter = Http4sEmitter.build[IO](collector, client, bufferConfig)(implicitly, rng)
-      beforeClose <- emitter.use { e => List.fill(events)(e.send(payload)).sequence_ >> IO.sleep(100.millis) >> ref.get }
+      beforeClose <- emitter.use { e => List.fill(events)(e.send(payload)).sequence_ >> IO.sleep(300.millis) >> ref.get }
       afterClose <- ref.get
     } yield (beforeClose, afterClose)
 

--- a/modules/metadata/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/Ec2Metadata.scala
+++ b/modules/metadata/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/Ec2Metadata.scala
@@ -16,13 +16,11 @@ import com.snowplowanalytics.snowplow.scalatracker.SelfDescribingJson
 
 import scala.concurrent.duration._
 import cats.implicits._
-import cats.effect.{Concurrent, Sync}
+import cats.effect.{Async, Concurrent, Sync}
 import io.circe.{Json, JsonObject}
 import io.circe.syntax._
 import io.circe.parser.parse
 import scalaj.http.Http
-import cats.effect.Temporal
-import cats.effect.kernel.Async
 
 /**
   * Module with parsing EC2-metadata logic
@@ -122,7 +120,7 @@ class Ec2Metadata[F[_]: Async](client: HttpClient = _.asString) {
     * @return value wrapped delayed inside F
     */
   private[metadata] def getContent(url: String): F[String] =
-    Sync[F].delay(client(Http(url)).body)
+    Sync[F].interruptible(client(Http(url)).body)
 
   /**
     * Get content of node-link

--- a/modules/metadata/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/GceMetadata.scala
+++ b/modules/metadata/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/GceMetadata.scala
@@ -13,16 +13,12 @@
 package com.snowplowanalytics.snowplow.scalatracker.metadata
 
 import scala.concurrent.duration._
-
 import cats.implicits._
-import cats.effect.{Concurrent, Sync, Timer}
-
+import cats.effect.{Async, Concurrent, Sync}
 import io.circe.Json
 import io.circe.syntax._
 import io.circe.parser.parse
-
 import scalaj.http.{Http, HttpRequest}
-
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
 import com.snowplowanalytics.snowplow.scalatracker.SelfDescribingJson
 
@@ -34,7 +30,7 @@ import com.snowplowanalytics.snowplow.scalatracker.SelfDescribingJson
   * Unlike EC2 instance document, GCE does not provide an excerpt, but instead
   * this module collect only meaningful properties
   */
-class GceMetadata[F[_]: Sync](client: HttpClient = _.asString) {
+class GceMetadata[F[_]: Async](client: HttpClient = _.asString) {
 
   val InstanceMetadataSchema: SchemaKey =
     SchemaKey("com.google.cloud.gce", "instance_metadata", "jsonschema", SchemaVer.Full(1, 0, 0))
@@ -46,8 +42,8 @@ class GceMetadata[F[_]: Sync](client: HttpClient = _.asString) {
     *
     * @return some context or None in case of any error including 3 sec timeout
     */
-  def getInstanceContextBlocking(implicit F: Concurrent[F], T: Timer[F]): F[Option[SelfDescribingJson]] =
-    Concurrent.timeoutTo(getInstanceContext.map(_.some), 3.seconds, Option.empty[SelfDescribingJson].pure[F])
+  def getInstanceContextBlocking: F[Option[SelfDescribingJson]] =
+    Concurrent[F].timeoutTo(getInstanceContext.map(_.some), 3.seconds, Option.empty[SelfDescribingJson].pure[F])
 
   /**
     * Tries to GET self-describing JSON with instance identity

--- a/modules/metadata/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/GceMetadata.scala
+++ b/modules/metadata/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/GceMetadata.scala
@@ -82,7 +82,7 @@ class GceMetadata[F[_]: Async](client: HttpClient = _.asString) {
     Http(InstanceMetadataUri + path).header("Metadata-Flavor", "Google")
 
   private[metadata] def getString(path: String): F[String] =
-    Sync[F].delay(client(request(path)).body)
+    Sync[F].interruptible(client(request(path)).body)
 
   private def getJson(path: String): F[Json] =
     getString(path).flatMap { string =>

--- a/modules/metadata/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/package.scala
+++ b/modules/metadata/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/package.scala
@@ -13,7 +13,7 @@
 package com.snowplowanalytics.snowplow.scalatracker
 
 import cats.implicits._
-import cats.effect.Sync
+import cats.effect.kernel.Async
 import scalaj.http.{HttpRequest, HttpResponse}
 
 package object metadata {
@@ -26,14 +26,14 @@ package object metadata {
       * Adds EC2 context to each sent event
       * Blocks event queue until either context resolved or timed out
       */
-    def enableEc2Context[G[_]: Sync](): G[Tracker[F]] =
+    def enableEc2Context[G[_]: Async](): G[Tracker[F]] =
       new Ec2Metadata[G]().getInstanceContext.map(metadata => tracker.addContext(metadata))
 
     /**
       * Adds GCP context to each sent event
       * Blocks event queue until either context resolved or timed out
       */
-    def enableGceContext[G[_]: Sync](): G[Tracker[F]] =
+    def enableGceContext[G[_]: Async](): G[Tracker[F]] =
       new GceMetadata[G]().getInstanceContext.map(metadata => tracker.addContext(metadata))
 
   }

--- a/modules/metadata/src/test/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/MetadataSpec.scala
+++ b/modules/metadata/src/test/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/MetadataSpec.scala
@@ -96,7 +96,7 @@ class MetadataSpec extends Specification {
   def e5 = {
 
     val client: HttpClient = { _ =>
-      Thread.sleep(5000)
+      Thread.sleep(30000)
       HttpResponse(ec2Response, 200, Map.empty)
     }
 
@@ -105,7 +105,7 @@ class MetadataSpec extends Specification {
 
   def e6 = {
     val client: HttpClient = { _ =>
-      Thread.sleep(5000)
+      Thread.sleep(30000)
       HttpResponse(gceResponse, 200, Map.empty)
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,8 @@ object Dependencies {
     val scalajHttp  = "2.4.2"
     val igluCore    = "1.0.1"
     val circe       = "0.14.1"
-    val catsEffect  = "2.5.3"
-    val http4s      = "0.22.4"
+    val catsEffect  = "3.3.5"
+    val http4s      = "0.23.10"
 
     // Java
     val slf4j       = "1.7.32"


### PR DESCRIPTION
Follow up to #172 

This PR upgrades cats-effect to 3.x, on both http4s-emitter and metadata modules, which also means upgrading to fs2 3.
Http4s was also updated to 0.23.x the most recent stable release built on top of CE3 and fs2 3.

A few things changed in these major versions, directly impacting http4s-emitter code.

First, `fs2.concurrent.Queue` has been reworked and moved into cats-effect (`cats.effect.std.Queue`). `Enqueue` and `Dequeue` (fs2 parent traits of `Queue`) have been renamed to `QueueSource` and `QueueSink`. Note that, confusingly enough, `Dequeue` in cats-effect in an entirely different data structure, i.e. a double-ended queue.
`enqueue1` has been basically renamed to `offer` (blocking semantics when queue is full), while `offer1` has been renamed to `tryOffer` (immediately returns with a boolean signaling success/failure).
See https://github.com/typelevel/fs2/blob/v2.5.10/core/shared/src/main/scala/fs2/concurrent/Queue.scala and https://github.com/typelevel/cats-effect/blob/series/3.x/std/shared/src/main/scala/cats/effect/std/Queue.scala 
`Queue.dequeue` has been dropped, and replaced by a bunch of `Stream.fromQueue...` methods. The old `dequeue` used to return a stream, and dequeuing items in chunks as big as possible by default (limit = Int.MaxValue), see 
https://github.com/typelevel/fs2/blob/24282e2268f489972252433b4b85e8c8ecf5109b/core/shared/src/main/scala/fs2/concurrent/Queue.scala#L84. The same API in fs2 3 is implemented by https://github.com/typelevel/fs2/blob/6b4be6642e8d83f2308d99a41b66796338b3d147/core/shared/src/main/scala/fs2/Stream.scala#L3339

Second, CE3's typeclass hierarchy is vastly different from the one in CE2, almost reversed. Migration was easy enough, with `Timer` becoming `Temporal`. `Temporal` now extends `Concurrent`, and in a few places, requiring Temporal + Sync/Concurrent was causing conflicts in the implicit scope, due to both extending the same parent traits (e.g. Monad, MonadError). So I found out that the idea is just to replace them with the least powerful typeclass that supports both constraint, which in many cases ends up being `Async`. This shouldn't be a problem for end users though. See https://gitter.im/typelevel/cats-effect?at=603ddd125d0bfb4e587f5d14

Third and final point, CE3 comes with UUIDGen and Random typeclasses, so that there is no need to use java methods wrapped in `Sync.delay`. This also addresses #154

Target of this PR is `release/2.0.0`, since this upgrade contains breaking changes. MiMa previous versions already cleared before merging #172 to the release branch.

 