### PR TITLE
Cross-compile to Scala 3.3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,23 +4,20 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         scala-version: [2.12.20, 2.13.16, 3.3.7]
-
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v6
+    - name: Setup JDK
+      uses: actions/setup-java@v5
       with:
-        java-version: 11
-
+        distribution: temurin
+        java-version: 17
+        cache: sbt
+    - uses: sbt/setup-sbt@v1
     - name: Run sbt
       run: sbt ++${{ matrix.scala-version }} coverage test coverageReport
-
     - name: Codecov
       run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        scala-version: [2.12.14, 2.13.6]
+        scala-version: [2.12.20, 2.13.16, 3.3.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/setup-java@v5
       with:
         distribution: temurin
-        java-version: 17
+        java-version: 11
         cache: sbt
     - uses: sbt/setup-sbt@v1
     - name: Run sbt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 11
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Run sbt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,22 +9,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v6
+      - name: Setup JDK
+        uses: actions/setup-java@v5
         with:
-          java-version: 11
-
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
       - name: Run sbt
         run: sbt +test
-
       - name: Check assets can be published
         run: sbt +publishLocal
-      
       - name: Check binary compatibility
         run: sbt +mimaReportBinaryIssues
-
       - name: Publish snowplow-scala-tracker to Maven Central
         run: sbt ci-release
         env:

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 2.3.2
+version = 3.11.1
 style = default
 maxColumn = 120
 optIn.breakChainOnFirstMethodDot = false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 The Snowplow Scala Tracker is a client library for sending analytics events to Snowplow collectors. It provides a purely functional, typesafe API for tracking user interactions, page views, transactions, and custom events. The tracker uses tagless final pattern with higher-kinded types (`F[_]`) to support different effect types and maintains referential transparency throughout the codebase.
 
 ### Key Technologies
-- **Scala**: 2.12.14, 2.13.6 (cross-compiled)
+- **Scala**: 2.12.20, 2.13.16, 3.3.7 (cross-compiled)
 - **Cats/Cats Effect**: Core FP abstractions and effect management
 - **Circe**: JSON encoding/decoding
 - **Iglu**: Schema registry integration for self-describing JSONs

--- a/build.sbt
+++ b/build.sbt
@@ -13,14 +13,14 @@
 
 lazy val commonSettings = Seq(
   organization := "com.snowplowanalytics",
-  scalaVersion := "2.13.6",
-  crossScalaVersions := Seq("2.12.14", "2.13.6"),
+  scalaVersion := "2.13.16",
+  crossScalaVersions := Seq("2.12.20", "2.13.16", "3.3.7"),
   scalacOptions := BuildSettings.compilerOptions(scalaVersion.value),
   javacOptions ++= BuildSettings.javaCompilerOptions,
   libraryDependencies ++= Seq(
     Dependencies.Libraries.specs2,
     Dependencies.Libraries.scalaCheck,
-    Dependencies.Libraries.circeOptics
+    Dependencies.circeOpticsFor(scalaVersion.value)
   ),
   ThisBuild / dynverVTagPrefix := false
 ) ++ BuildSettings.publishSettings // Otherwise git tags required to have v-prefix
@@ -56,7 +56,7 @@ lazy val idEmitter = project
   .settings(Seq(
     name := "snowplow-scala-tracker-emitter-id",
     libraryDependencies ++= Seq(
-      Dependencies.Libraries.scalajHttp,
+      Dependencies.scalajHttpFor(scalaVersion.value),
       Dependencies.Libraries.slf4jApi
     )
   ))
@@ -70,7 +70,7 @@ lazy val metadata = project
   .settings(Seq(
     name := "snowplow-scala-tracker-metadata",
     libraryDependencies ++= Seq(
-      Dependencies.Libraries.scalajHttp,
+      Dependencies.scalajHttpFor(scalaVersion.value),
       Dependencies.Libraries.catsEffect
     )
   ))

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.scalatracker/TrackerSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.scalatracker/TrackerSpec.scala
@@ -280,12 +280,12 @@ class TrackerSpec extends Specification {
         "iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-1"
       )
       data.message.string.getOption(json) must beSome("boom!")
-      data.stackTrace.string.getOption(json) must beSome.which(_.contains("java.lang.RuntimeException: boom!"))
-      data.threadName.string.getOption(json) must not(beSome.which(_.isEmpty))
-      data.threadId.json.getOption(json) must beSome.which(!_.isNull)
+      data.stackTrace.string.getOption(json) must beSome[String].which(_.contains("java.lang.RuntimeException: boom!"))
+      data.threadName.string.getOption(json) must not(beSome[String].which(_.isEmpty))
+      data.threadId.json.getOption(json) must beSome[Json].which(!_.isNull)
       data.programmingLanguage.string.getOption(json) must beSome("SCALA")
-      data.lineNumber.int.getOption(json) must beSome.which(_ > 0)
-      data.className.string.getOption(json) must beSome.which(_.contains(this.getClass.getName))
+      data.lineNumber.int.getOption(json) must beSome[Int].which(_ > 0)
+      data.className.string.getOption(json) must beSome[String].which(_.contains(this.getClass.getName))
       data.exceptionName.string.getOption(json) must beSome("java.lang.RuntimeException")
       data.isFatal.boolean.getOption(json) must beSome(true)
 

--- a/modules/http4s-emitter/src/test/scala/com/snowplowanalytics/snowplow/scalatracker/emitters/http4s/Http4sEmitterSpec.scala
+++ b/modules/http4s-emitter/src/test/scala/com/snowplowanalytics/snowplow/scalatracker/emitters/http4s/Http4sEmitterSpec.scala
@@ -17,7 +17,7 @@ import cats.effect.std.Random
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
 
-import org.http4s.Response
+import org.http4s.{Request, Response}
 import org.http4s.client.Client
 import com.snowplowanalytics.snowplow.scalatracker.{Emitter, Payload}
 import org.specs2.Specification
@@ -36,29 +36,33 @@ class Http4sEmitterSpec extends Specification {
 
   """
 
-  val payload = Payload(Map("foo" -> "bar", "bar" -> "foo"))
+  val payload                 = Payload(Map("foo" -> "bar", "bar" -> "foo"))
   val threeEventsPayloadBytes = Payload.postPayload(Seq(payload, payload, payload)).getBytes.length
-  val maxEventsBufferConfig = Emitter.BufferConfig.EventsCardinality(3)
-  val maxBytesBufferConfig = Emitter.BufferConfig.PayloadSize(threeEventsPayloadBytes)
+  val maxEventsBufferConfig   = Emitter.BufferConfig.EventsCardinality(3)
+  val maxBytesBufferConfig    = Emitter.BufferConfig.PayloadSize(threeEventsPayloadBytes)
 
-  def e1 = testEmitter(maxEventsBufferConfig, 2).unsafeRunSync() must_==((0, 1): (Int, Int))
+  def e1 = testEmitter(maxEventsBufferConfig, 2).unsafeRunSync() must_== ((0, 1): (Int, Int))
 
-  def e2 = testEmitter(maxEventsBufferConfig, 3).unsafeRunSync() must_==((1, 1): (Int, Int))
+  def e2 = testEmitter(maxEventsBufferConfig, 3).unsafeRunSync() must_== ((1, 1): (Int, Int))
 
-  def e3 = testEmitter(maxBytesBufferConfig, 2).unsafeRunSync() must_==((0, 1): (Int, Int))
+  def e3 = testEmitter(maxBytesBufferConfig, 2).unsafeRunSync() must_== ((0, 1): (Int, Int))
 
-  def e4 = testEmitter(maxBytesBufferConfig, 3).unsafeRunSync() must_==((1, 1): (Int, Int))
+  def e4 = testEmitter(maxBytesBufferConfig, 3).unsafeRunSync() must_== ((1, 1): (Int, Int))
 
-  def e5 = testEmitter(maxBytesBufferConfig, 1).unsafeRunSync() must_==((0, 1): (Int, Int))
+  def e5 = testEmitter(maxBytesBufferConfig, 1).unsafeRunSync() must_== ((0, 1): (Int, Int))
 
   def testEmitter(bufferConfig: Emitter.BufferConfig, events: Int): IO[(Int, Int)] =
     for {
       rng <- Random.scalaUtilRandom[IO]
       ref <- Ref.of[IO, Int](0)
       collector = Emitter.EndpointParams("example.com")
-      client = Client[IO] { _ => Resource.eval(ref.update(_ + 1)).as(Response[IO]()) }
+      client = Client[IO] { (_: Request[IO]) =>
+        Resource.eval(ref.update(n => n + 1).as(Response[IO]()))
+      }
       emitter = Http4sEmitter.build[IO](collector, client, bufferConfig)(implicitly, rng)
-      beforeClose <- emitter.use { e => List.fill(events)(e.send(payload)).sequence_ >> IO.sleep(900.millis) >> ref.get }
+      beforeClose <- emitter.use { e =>
+        List.fill(events)(e.send(payload)).sequence_ >> IO.sleep(900.millis) >> ref.get
+      }
       afterClose <- ref.get
     } yield (beforeClose, afterClose)
 

--- a/modules/id-emitter/src/test/scala/com/snowplowanalytics/snowplow/scalatracker/emitters/id/StressTest.scala
+++ b/modules/id-emitter/src/test/scala/com/snowplowanalytics/snowplow/scalatracker/emitters/id/StressTest.scala
@@ -52,7 +52,7 @@ object StressTest {
     def apply[A: Read] = implicitly[Read[A]]
   }
 
-  implicit val sdJsonsRead = new Read[List[SelfDescribingJson]] {
+  implicit val sdJsonsRead: Read[List[SelfDescribingJson]] = new Read[List[SelfDescribingJson]] {
     def parseJson(json: Json): SelfDescribingData[Json] =
       json
         .asObject
@@ -71,7 +71,7 @@ object StressTest {
 
   }
 
-  implicit val tstmpRead = new Read[Option[Timestamp]] {
+  implicit val tstmpRead: Read[Option[Timestamp]] = new Read[Option[Timestamp]] {
     def reads(line: String): Option[Timestamp] =
       line.split(":").toList match {
         case List("ttm", tstamp) => Some(TrueTimestamp(tstamp.toLong))
@@ -80,9 +80,9 @@ object StressTest {
       }
   }
 
-  implicit val eventRead = new Read[EventArguments] {
+  implicit val eventRead: Read[EventArguments] = new Read[EventArguments] {
     def reads(line: String): EventArguments = {
-      val cols = line.split("\t", -1).lift
+      val cols = line.split("\t", -1).toIndexedSeq.lift
       (cols(0), cols(1)) match {
         case (Some("pv"), Some(url)) =>
           val ctx: Option[List[SelfDescribingJson]] = cols(4).map(sdJsonsRead.reads)

--- a/modules/metadata/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/Ec2Metadata.scala
+++ b/modules/metadata/src/main/scala/com/snowplowanalytics/snowplow/scalatracker/metadata/Ec2Metadata.scala
@@ -58,7 +58,7 @@ class Ec2Metadata[F[_]: Async](client: HttpClient = _.asString) {
     */
   def getInstanceIdentity: F[Json] = {
     val instanceIdentityDocument = getContent(InstanceIdentityUri)
-    instanceIdentityDocument.flatMap { resp: String =>
+    instanceIdentityDocument.flatMap { (resp: String) =>
       parse(resp)
         .toOption
         .flatMap(_.asObject)

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -40,18 +40,29 @@ object BuildSettings {
     }.taskValue
   )
 
-  def compilerOptions(scalaVersion: String) = Seq(
-    "-deprecation",
-    "-encoding", "UTF-8",
-    "-feature",
-    "-language:existentials",
-    "-language:higherKinds",
-    "-language:implicitConversions",
-    "-unchecked",
-    "-Ywarn-dead-code",
-    "-Ywarn-numeric-widen",
-    "-Xlint"
-  ) ++ (if (priorTo2_13(scalaVersion)) Seq("-Ypartial-unification", "-Xfuture") else Nil )
+  def compilerOptions(scalaVersion: String) =
+    if (isScala3(scalaVersion))
+      Seq(
+        "-deprecation",
+        "-encoding", "UTF-8",
+        "-feature",
+        "-language:higherKinds",
+        "-language:implicitConversions",
+        "-unchecked"
+      )
+    else
+      Seq(
+        "-deprecation",
+        "-encoding", "UTF-8",
+        "-feature",
+        "-language:existentials",
+        "-language:higherKinds",
+        "-language:implicitConversions",
+        "-unchecked",
+        "-Ywarn-dead-code",
+        "-Ywarn-numeric-widen",
+        "-Xlint"
+      ) ++ (if (priorTo2_13(scalaVersion)) Seq("-Ypartial-unification", "-Xfuture") else Nil)
 
   lazy val javaCompilerOptions = Seq(
     "-source", "1.8",
@@ -62,6 +73,12 @@ object BuildSettings {
     CrossVersion.partialVersion(scalaVersion) match {
       case Some((2, minor)) if minor < 13 => true
       case _                              => false
+    }
+
+  def isScala3(scalaVersion: String): Boolean =
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((3, _)) => true
+      case _            => false
     }
 
   // Maven publishing settings

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,11 +55,11 @@ object Dependencies {
     val circeOpticsScala3 = "io.circe"       %% "circe-optics" % V.circeOpticsScala3 % "test"
   }
 
-  /** scalaj-http: the org.scalaj artifact for Scala 2, the com.codacy drop-in fork for Scala 3. */
+  // scalaj-http: the org.scalaj artifact for Scala 2, the com.codacy drop-in fork for Scala 3
   def scalajHttpFor(scalaVersion: String) =
-    if (scalaVersion.startsWith("3")) Libraries.scalajHttpScala3 else Libraries.scalajHttp
+    if (BuildSettings.isScala3) Libraries.scalajHttpScala3 else Libraries.scalajHttp
 
-  /** circe-optics: 0.14.x for Scala 2, 0.15.x (first Scala 3 build) for Scala 3. */
+  // circe-optics: 0.14.x for Scala 2 because there is no 0.15.x for Scala 2.12
   def circeOpticsFor(scalaVersion: String) =
-    if (scalaVersion.startsWith("3")) Libraries.circeOpticsScala3 else Libraries.circeOptics
+    if (BuildSettings.isScala3) Libraries.circeOpticsScala3 else Libraries.circeOptics
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,35 +16,50 @@ object Dependencies {
 
   object V {
     // Scala
-    val scalajHttp  = "2.4.2"
-    val igluCore    = "1.0.1"
-    val circe       = "0.14.1"
-    val catsEffect  = "3.3.5"
-    val http4s      = "0.23.15"
+    val scalajHttp       = "2.4.2"
+    // org.scalaj publishes no Scala 3 build; com.codacy maintains a drop-in fork
+    val scalajHttpScala3 = "2.5.0"
+    val igluCore         = "1.1.4"
+    val circe            = "0.14.1"
+    val catsEffect       = "3.3.5"
+    val http4s           = "0.23.15"
 
     // Java
     val slf4j       = "1.7.32"
 
     // Scala (test only)
-    val specs2      = "4.12.3"
-    val scalaCheck  = "1.15.4"
+    val specs2            = "4.20.9"
+    val scalaCheck        = "1.17.0"
+    val circeOptics       = "0.14.1"
+    // circe-optics only publishes a Scala 3 build from 0.15.0 onwards
+    val circeOpticsScala3 = "0.15.0"
   }
 
   object Libraries {
     // Scala
-    val scalajHttp     = "org.scalaj"            %% "scalaj-http"     % V.scalajHttp
-    val igluCore       = "com.snowplowanalytics" %% "iglu-core"       % V.igluCore
-    val igluCoreCirce  = "com.snowplowanalytics" %% "iglu-core-circe" % V.igluCore
-    val circe          = "io.circe"              %% "circe-parser"    % V.circe
-    val catsEffect     = "org.typelevel"         %% "cats-effect"     % V.catsEffect
-    val http4sClient   = "org.http4s"            %% "http4s-client"   % V.http4s
+    val scalajHttp       = "org.scalaj"            %% "scalaj-http"     % V.scalajHttp
+    val scalajHttpScala3 = "com.codacy"            %% "scalaj-http"     % V.scalajHttpScala3
+    val igluCore         = "com.snowplowanalytics" %% "iglu-core"       % V.igluCore
+    val igluCoreCirce    = "com.snowplowanalytics" %% "iglu-core-circe" % V.igluCore
+    val circe            = "io.circe"              %% "circe-parser"    % V.circe
+    val catsEffect       = "org.typelevel"         %% "cats-effect"     % V.catsEffect
+    val http4sClient     = "org.http4s"            %% "http4s-client"   % V.http4s
 
     // Java
     val slf4jApi = "org.slf4j" % "slf4j-api" % V.slf4j
 
     // Scala (test only)
-    val specs2        = "org.specs2"             %% "specs2-core"         % V.specs2      % "test"
-    val scalaCheck    = "org.scalacheck"         %% "scalacheck"          % V.scalaCheck  % "test"
-    val circeOptics   = "io.circe"               %% "circe-optics"        % V.circe       % "test"
+    val specs2            = "org.specs2"     %% "specs2-core"  % V.specs2            % "test"
+    val scalaCheck        = "org.scalacheck" %% "scalacheck"   % V.scalaCheck        % "test"
+    val circeOptics       = "io.circe"       %% "circe-optics" % V.circeOptics       % "test"
+    val circeOpticsScala3 = "io.circe"       %% "circe-optics" % V.circeOpticsScala3 % "test"
   }
+
+  /** scalaj-http: the org.scalaj artifact for Scala 2, the com.codacy drop-in fork for Scala 3. */
+  def scalajHttpFor(scalaVersion: String) =
+    if (scalaVersion.startsWith("3")) Libraries.scalajHttpScala3 else Libraries.scalajHttp
+
+  /** circe-optics: 0.14.x for Scala 2, 0.15.x (first Scala 3 build) for Scala 3. */
+  def circeOpticsFor(scalaVersion: String) =
+    if (scalaVersion.startsWith("3")) Libraries.circeOpticsScala3 else Libraries.circeOptics
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,9 +57,9 @@ object Dependencies {
 
   // scalaj-http: the org.scalaj artifact for Scala 2, the com.codacy drop-in fork for Scala 3
   def scalajHttpFor(scalaVersion: String) =
-    if (BuildSettings.isScala3) Libraries.scalajHttpScala3 else Libraries.scalajHttp
+    if (BuildSettings.isScala3(scalaVersion)) Libraries.scalajHttpScala3 else Libraries.scalajHttp
 
   // circe-optics: 0.14.x for Scala 2 because there is no 0.15.x for Scala 2.12
   def circeOpticsFor(scalaVersion: String) =
-    if (BuildSettings.isScala3) Libraries.circeOpticsScala3 else Libraries.circeOptics
+    if (BuildSettings.isScala3(scalaVersion)) Libraries.circeOpticsScala3 else Libraries.circeOptics
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.10.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.12")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.12")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")


### PR DESCRIPTION
Add Scala 3.3.7 to the cross-build alongside Scala 2.12 and 2.13.

Build:
- Bump sbt 1.5.5 -> 1.10.7 and plugins (scoverage 2.0.12 for Scala 3 coverage, ci-release com.geirsson -> com.github.sbt, mima 1.1.3, scalafmt 2.5.2).
- Branch compilerOptions for Scala 3 (drop -Y*/-Xlint/-language:existentials).

Dependencies:
- iglu-core 1.0.1 -> 1.1.4 (first release with _3 artifacts).
- Test: specs2 4.12.3 -> 4.20.9, scalacheck 1.15.4 -> 1.17.0.
- scalaj-http: org.scalaj has no Scala 3 build, so use the drop-in com.codacy fork on Scala 3 only via scalajHttpFor.
- circe-optics: 0.14.1 on Scala 2, 0.15.0 (first _3) on Scala 3 via circeOpticsFor. (the **0.15.x dropped 2.12**)

Source fixes for Scala 3 (all valid in Scala 2 too):
- Ec2Metadata: parenthesize type-annotated lambda param.
- TrackerSpec: beSome.which -> beSome[T].which to fix Nothing inference.
- StressTest: explicit types on implicit vals; Array.lift -> toIndexedSeq.lift.
- Http4sEmitterSpec: disambiguate nested _ lambda placeholders.

Bump Scala 2 patch versions 2.12.14 -> 2.12.20 and 2.13.6 -> 2.13.16 (same-minor, source/binary compatible) so the toolchain builds on Java 21.

Update CI matrix and CLAUDE.md to the new versions.

<!--
Thank you for contributing to the Snowplow Scala Tracker!

You'll find a small checklist below which should help speed up the
review processs:

- [ ] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [ ] Have you read the [contributing guide](https://github.com/snowplow/snowplow-scala-tracker/blob/master/CONTRIBUTING.md)?
- [ ] Have you added the appropriate unit tests?
- [ ] Have you run the tests through `sbt test`?
-->
